### PR TITLE
prettier-plugin-tailwindcssが動作するように修正

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,3 @@
 {
-  "plugins": ["prettier-plugin-tailwindcss", "prettier-plugin-astro"]
+  "plugins": ["prettier-plugin-astro", "prettier-plugin-tailwindcss"]
 }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -27,8 +27,8 @@ const { thumbnail, title, path } = Astro.props;
     <title>Hiroki SAKABE</title>
   </head>
   <body>
-    <div class="flex flex-col lg:flex-row px-10">
-      <div class="lg:w-64 lg:fixed">
+    <div class="flex flex-col px-10 lg:flex-row">
+      <div class="lg:fixed lg:w-64">
         <div class="flex flex-col items-center lg:h-screen lg:flex-row">
           <a href="/">
             <div class="flex flex-col items-center">


### PR DESCRIPTION
prettier-plugin-tailwindcssが動作するように修正した
ただし、JavaScript構文内は未だフォーマットされない...

```astro
<Layout
  title={postDetail.title}
  path={`/posts/${postId}/`}
  thumbnail={`/posts/${postId}/ogp.png`}
>
  <div class="space-y-7 ここはフォーマットされる">
    <div class="shadow-md">
      {
        postDetail ? (
          <div class="p-3 ここはフォーマットされない">
```

参考 : https://astro-tips.dev/tips/prettier/#prettier-plugin-for-tailwind-css
