### PR TITLE
Dependabot PR で E2E テストが secrets にアクセスできるようにする

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,14 +2,28 @@ name: CI
 
 on:
   pull_request:
+  pull_request_target:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
+    # pull_request_target は Dependabot PR のみ実行（secrets アクセスのため）
+    # pull_request は Dependabot 以外の PR で実行
+    # push は main ブランチへのプッシュで実行
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]') ||
+      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".node-version"


### PR DESCRIPTION
close #138

## Summary

- Dependabot PR で `pull_request_target` イベントを使用し、secrets（`X_MICROCMS_API_KEY`）にアクセスできるようにする
- `github.actor == 'dependabot[bot]'` の条件で Dependabot PR のみに限定し、セキュリティリスクを最小化
- `permissions: contents: read` と `persist-credentials: false` で権限を最小化

## 変更内容

- `pull_request_target` トリガーを追加
- `if` 条件でイベント種別ごとの実行制御を追加（Dependabot 以外の PR では従来の `pull_request` を使用）
- `pull_request_target` 時は PR の HEAD SHA をチェックアウト
- ワークフローレベルで `permissions: contents: read` を設定
- `actions/checkout` に `persist-credentials: false` を追加

## Test plan

- [ ] 通常の PR で CI が従来通り動作することを確認
- [ ] Dependabot PR で E2E テストが secrets にアクセスでき、テストが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)