### PR TITLE
ESLint がビルド出力を検査しないよう .eslintignore を追加

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+dist/
+.astro/
+.vercel/


### PR DESCRIPTION
close #145

## 概要

- `.eslintignore` を新規追加し、`dist/`, `.astro/`, `.vercel/` をESLintの検査対象から除外
- ビルド後に `npm run lint` を実行した際、ソース変更と無関係なエラーが発生する問題を解消

## テスト計画

- [x] `npm run lint` が正常に完了することを確認
- [x] `npm run format:check` が正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)