### PR TITLE
見た目を SNS 風のタイムラインに変更

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -48,106 +48,108 @@ const {
       }
     </title>
   </head>
-  <body>
-    <div class="flex min-h-screen flex-col px-10 lg:flex-row">
-      <div class="lg:fixed lg:w-64">
-        <div class="flex flex-col items-center lg:h-screen lg:flex-row">
-          <div class="flex flex-col items-center">
-            <a href="/">
-              <div class="flex flex-col items-center">
-                <div class="w-28 lg:w-fit">
-                  <img
-                    src="/icon.jpg"
-                    alt={""}
-                    width={200}
-                    height={200}
-                    class="rounded-full"
-                  />
-                </div>
-                <div class="text-center">
-                  <div class="text-2xl">Hiroki SAKABE</div>
-                </div>
-                <div class="py-3 text-center">
-                  <div class="text-base">
-                    プログラミングと旅行が好きな
-                    <br />
-                    ミニマリスト
-                  </div>
-                </div>
+  <body class="bg-white text-gray-900">
+    <div class="mx-auto flex min-h-screen max-w-5xl flex-col lg:flex-row">
+      <aside
+        class="border-gray-200 px-6 py-6 lg:fixed lg:h-screen lg:w-72 lg:border-r lg:px-8 lg:py-10"
+      >
+        <div class="flex flex-col items-center lg:items-start">
+          <a href="/" class="group">
+            <div class="flex flex-col items-center lg:items-start">
+              <div class="w-24 lg:w-28">
+                <img
+                  src="/icon.jpg"
+                  alt={""}
+                  width={200}
+                  height={200}
+                  class="rounded-full ring-1 ring-gray-200 transition group-hover:ring-gray-300"
+                />
               </div>
-            </a>
-            <div class="flex gap-4">
-              <a
-                href="https://github.com/hirokisakabe"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="GitHub"
+              <div class="mt-3 text-center lg:text-left">
+                <div class="text-xl font-bold">Hiroki SAKABE</div>
+                <div class="text-sm text-gray-500">@hirokisakabe</div>
+              </div>
+              <p
+                class="mt-3 text-center text-sm leading-relaxed text-gray-700 lg:text-left"
               >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                  role="img"
-                  aria-hidden="true"
-                >
-                  <path
-                    d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
-                  ></path>
-                </svg>
-              </a>
-              <a
-                href="https://zenn.dev/hirokisakabe"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Zenn"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                  role="img"
-                  aria-hidden="true"
-                >
-                  <path
-                    d="M.264 23.771h4.984c.264 0 .498-.147.645-.352L19.614.874c.176-.293-.029-.645-.381-.645h-4.72c-.235 0-.44.117-.557.323L.03 23.361c-.088.176.029.41.234.41zM17.445 23.419l6.479-10.408c.205-.323-.029-.733-.41-.733h-4.691c-.176 0-.352.088-.44.235l-6.655 10.643c-.176.264.029.616.352.616h4.779c.205-.001.381-.118.586-.353z"
-                  ></path>
-                </svg>
-              </a>
-              <a
-                href="https://x.com/hirokisakabe"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="X"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                  role="img"
-                  aria-hidden="true"
-                >
-                  <path
-                    d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"
-                  ></path>
-                </svg>
-              </a>
+                プログラミングと旅行が好きな<br />ミニマリスト
+              </p>
             </div>
+          </a>
+          <div class="mt-4 flex gap-4 text-gray-500">
+            <a
+              href="https://github.com/hirokisakabe"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="GitHub"
+              class="transition hover:text-gray-900"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                role="img"
+                aria-hidden="true"
+              >
+                <path
+                  d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
+                ></path>
+              </svg>
+            </a>
+            <a
+              href="https://zenn.dev/hirokisakabe"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Zenn"
+              class="transition hover:text-gray-900"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                role="img"
+                aria-hidden="true"
+              >
+                <path
+                  d="M.264 23.771h4.984c.264 0 .498-.147.645-.352L19.614.874c.176-.293-.029-.645-.381-.645h-4.72c-.235 0-.44.117-.557.323L.03 23.361c-.088.176.029.41.234.41zM17.445 23.419l6.479-10.408c.205-.323-.029-.733-.41-.733h-4.691c-.176 0-.352.088-.44.235l-6.655 10.643c-.176.264.029.616.352.616h4.779c.205-.001.381-.118.586-.353z"
+                ></path>
+              </svg>
+            </a>
+            <a
+              href="https://x.com/hirokisakabe"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="X"
+              class="transition hover:text-gray-900"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                role="img"
+                aria-hidden="true"
+              >
+                <path
+                  d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"
+                ></path>
+              </svg>
+            </a>
           </div>
         </div>
-      </div>
-      <div
-        class="flex flex-1 flex-col lg:ml-64 lg:border-l lg:border-gray-200 lg:px-3"
-      >
-        <main class="flex flex-1 flex-col py-6">
+      </aside>
+      <div class="flex flex-1 flex-col lg:ml-72">
+        <main class="flex flex-1 flex-col">
           <slot />
         </main>
-        <footer class="py-4 text-center text-sm text-gray-500">
+        <footer
+          class="border-t border-gray-200 px-4 py-6 text-center text-sm text-gray-500"
+        >
           <p>
             &copy; {new Date().getFullYear()} Hiroki SAKABE. All rights reserved.
           </p>

--- a/src/lib/post.ts
+++ b/src/lib/post.ts
@@ -17,6 +17,21 @@ export async function getPostList() {
   }));
 }
 
+export async function getFeedPosts() {
+  const posts = await getCollection("posts");
+  return Promise.all(
+    sortByPublishedAtDesc(posts).map(async (post) => {
+      const { Content } = await render(post);
+      return {
+        id: post.id,
+        title: post.data.title,
+        publishedAt: post.data.publishedAt,
+        Content,
+      };
+    }),
+  );
+}
+
 export async function getPostIds() {
   const posts = await getCollection("posts");
   return sortByPublishedAtDesc(posts).map((post) => post.id);

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -3,12 +3,14 @@ import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout title="ページが見つかりません" thumbnail="/ogp.png" path="/404">
-  <div class="flex flex-1 flex-col items-center justify-center space-y-4">
-    <h1 class="text-6xl font-bold text-gray-800">404</h1>
+  <div
+    class="flex flex-1 flex-col items-center justify-center space-y-4 px-4 py-16"
+  >
+    <h1 class="text-6xl font-bold text-gray-900">404</h1>
     <p class="text-lg text-gray-500">ページが見つかりませんでした</p>
     <a
       href="/"
-      class="rounded-lg bg-gray-800 px-6 py-2 text-white transition hover:bg-gray-700"
+      class="rounded-full bg-gray-900 px-6 py-2 text-white transition hover:bg-gray-700"
     >
       トップページへ戻る
     </a>

--- a/src/pages/[...page].astro
+++ b/src/pages/[...page].astro
@@ -1,11 +1,12 @@
 ---
 import Layout from "../layouts/Layout.astro";
-import { getPostList } from "../lib/post";
-import { format } from "date-fns";
+import { getFeedPosts } from "../lib/post";
+import { format, formatDistanceToNowStrict, isThisYear } from "date-fns";
+import { ja } from "date-fns/locale";
 import type { GetStaticPathsOptions } from "astro";
 
 export async function getStaticPaths({ paginate }: GetStaticPathsOptions) {
-  const posts = await getPostList();
+  const posts = await getFeedPosts();
 
   return paginate(posts, { pageSize: 10 });
 }
@@ -13,66 +14,112 @@ export async function getStaticPaths({ paginate }: GetStaticPathsOptions) {
 const range = (start: number, end: number) =>
   [...Array(end - start + 1)].map((_, i) => start + i);
 
+function formatTimestamp(date: Date) {
+  const diffMs = Date.now() - date.getTime();
+  const oneDayMs = 24 * 60 * 60 * 1000;
+  if (diffMs >= 0 && diffMs < oneDayMs) {
+    return formatDistanceToNowStrict(date, { addSuffix: false, locale: ja });
+  }
+  return isThisYear(date) ? format(date, "M月d日") : format(date, "yyyy/M/d");
+}
+
 const { page } = Astro.props;
 ---
 
 <Layout title="hirokisakabe.com" path="/" thumbnail={`/ogp.png`}>
-  <div class="space-y-7 pb-6">
+  <header
+    class="sticky top-0 z-10 border-b border-gray-200 bg-white/80 px-4 py-3 backdrop-blur"
+  >
+    <h1 class="text-lg font-bold">Posts</h1>
+  </header>
+  <ul class="divide-y divide-gray-200">
     {
-      page.data.map((content) => {
-        return (
-          <a
-            href={`/posts/${content.id}`}
-            class="block rounded-lg px-3 py-5 shadow-md transition hover:shadow-lg"
-          >
-            <h3 class="font-medium">{content.title}</h3>
-            <div class="pt-3 text-xs">
-              {format(content.publishedAt, "yyyy/MM/dd")}
+      page.data.map((content) => (
+        <li class="px-4 py-4 transition hover:bg-gray-50">
+          <article class="flex gap-3">
+            <a
+              href={`/posts/${content.id}`}
+              aria-label={content.title}
+              class="flex-shrink-0"
+            >
+              <img
+                src="/icon.jpg"
+                alt=""
+                width={40}
+                height={40}
+                class="h-10 w-10 rounded-full"
+              />
+            </a>
+            <div class="min-w-0 flex-1">
+              <div class="flex flex-wrap items-baseline gap-x-1.5 text-sm">
+                <span class="font-bold text-gray-900">Hiroki SAKABE</span>
+                <span class="text-gray-500">@hirokisakabe</span>
+                <span class="text-gray-500">·</span>
+                <a
+                  href={`/posts/${content.id}`}
+                  class="text-gray-500 transition hover:underline"
+                >
+                  <time datetime={content.publishedAt.toISOString()}>
+                    {formatTimestamp(content.publishedAt)}
+                  </time>
+                </a>
+              </div>
+              <h2 class="mt-0.5">
+                <a
+                  href={`/posts/${content.id}`}
+                  class="text-base font-semibold text-gray-900 transition hover:underline"
+                >
+                  {content.title}
+                </a>
+              </h2>
+              <div class="prose prose-sm prose-img:max-w-full prose-img:max-h-80 prose-img:w-auto prose-img:h-auto prose-img:rounded-xl mt-2 max-w-none">
+                <content.Content />
+              </div>
             </div>
-          </a>
-        );
-      })
+          </article>
+        </li>
+      ))
     }
-    <nav
-      class="flex items-center justify-center gap-2"
-      aria-label="ページネーション"
-    >
-      {
-        page.url.prev && (
-          <a
-            href={page.url.prev}
-            class="rounded-md border border-gray-300 px-3 py-1 text-sm transition hover:bg-gray-100"
-          >
-            前へ
-          </a>
-        )
-      }
-      {
-        range(1, Math.ceil(page.total / page.size)).map((number) => (
-          <a
-            href={number === 1 ? "/" : `/${number}`}
-            class:list={[
-              "rounded-md px-3 py-1 text-sm transition",
-              page.currentPage === number
-                ? "bg-gray-800 font-bold text-white"
-                : "border border-gray-300 hover:bg-gray-100",
-            ]}
-            aria-current={page.currentPage === number ? "page" : undefined}
-          >
-            {number}
-          </a>
-        ))
-      }
-      {
-        page.url.next && (
-          <a
-            href={page.url.next}
-            class="rounded-md border border-gray-300 px-3 py-1 text-sm transition hover:bg-gray-100"
-          >
-            次へ
-          </a>
-        )
-      }
-    </nav>
-  </div>
+  </ul>
+  <nav
+    class="flex items-center justify-center gap-2 px-4 py-6"
+    aria-label="ページネーション"
+  >
+    {
+      page.url.prev && (
+        <a
+          href={page.url.prev}
+          class="rounded-full border border-gray-300 px-3 py-1 text-sm transition hover:bg-gray-100"
+        >
+          前へ
+        </a>
+      )
+    }
+    {
+      range(1, Math.ceil(page.total / page.size)).map((number) => (
+        <a
+          href={number === 1 ? "/" : `/${number}`}
+          class:list={[
+            "rounded-full px-3 py-1 text-sm transition",
+            page.currentPage === number
+              ? "bg-gray-900 font-bold text-white"
+              : "border border-gray-300 hover:bg-gray-100",
+          ]}
+          aria-current={page.currentPage === number ? "page" : undefined}
+        >
+          {number}
+        </a>
+      ))
+    }
+    {
+      page.url.next && (
+        <a
+          href={page.url.next}
+          class="rounded-full border border-gray-300 px-3 py-1 text-sm transition hover:bg-gray-100"
+        >
+          次へ
+        </a>
+      )
+    }
+  </nav>
 </Layout>

--- a/src/pages/posts/[postId].astro
+++ b/src/pages/posts/[postId].astro
@@ -24,15 +24,58 @@ const postDetail = await getPostDetail(postId);
   thumbnail={`/posts/${postId}/ogp.png`}
   description={extractDescription(postDetail.body)}
 >
-  <div class="rounded-lg px-3 py-5 shadow-md">
-    <h1 class="text-2xl font-medium">{postDetail.title}</h1>
-    <div class="pt-3 text-xs text-slate-600">
-      {format(postDetail.publishedAt, "yyyy/MM/dd")}
+  <header
+    class="sticky top-0 z-10 border-b border-gray-200 bg-white/80 px-4 py-3 backdrop-blur"
+  >
+    <a
+      href="/"
+      class="inline-flex items-center gap-2 text-sm text-gray-700 transition hover:text-gray-900"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M19 12H5"></path>
+        <path d="m12 19-7-7 7-7"></path>
+      </svg>
+      <span class="font-bold">Post</span>
+    </a>
+  </header>
+  <article class="px-4 py-4">
+    <div class="flex items-center gap-3">
+      <img
+        src="/icon.jpg"
+        alt=""
+        width={48}
+        height={48}
+        class="h-12 w-12 flex-shrink-0 rounded-full"
+      />
+      <div class="leading-tight">
+        <div class="text-sm font-bold text-gray-900">Hiroki SAKABE</div>
+        <div class="text-sm text-gray-500">@hirokisakabe</div>
+      </div>
     </div>
+    <h1 class="mt-4 text-2xl font-bold text-gray-900">{postDetail.title}</h1>
     <div
-      class="prose prose-sm prose-h1:text-xl prose-h2:text-lg prose-h3:text-base prose-img:max-w-full prose-img:h-auto prose-img:rounded-xl lg:prose-img:max-w-xl mt-5 max-w-none"
+      class="prose prose-sm prose-h1:text-xl prose-h2:text-lg prose-h3:text-base prose-img:max-w-full prose-img:h-auto prose-img:rounded-xl lg:prose-img:max-w-xl mt-4 max-w-none"
     >
       <postDetail.Content />
     </div>
-  </div>
+    <div class="mt-5 border-t border-gray-200 pt-3">
+      <time
+        datetime={postDetail.publishedAt.toISOString()}
+        class="text-sm text-gray-500"
+      >
+        {format(postDetail.publishedAt, "yyyy年M月d日 HH:mm")}
+      </time>
+    </div>
+  </article>
 </Layout>


### PR DESCRIPTION
## Summary

- ブログ全体の見た目を Twitter / Threads 風のタイムラインレイアウトに刷新
- プロフィール枠にハンドル `@hirokisakabe` を追加し、SNS アカウントのような佇まいに
- 一覧をフィード形式（アバター + 名前 + ハンドル + 相対時刻 + タイトル + 本文）にし、詳細ページを開かずとも本文まで読めるように変更
- カードの shadow ベース → 薄いボーダー区切り、sticky ヘッダー追加、ボタンを pill 化
- 一覧フィード内の画像は `max-h-80` で表示サイズ制限（長尺画像でフィードが崩れないため）

## 変更内容

| ファイル | 主な変更 |
| --- | --- |
| `src/layouts/Layout.astro` | サイドバーをハンドル付きプロフィール風に、`max-w-5xl` で中央寄せ、フッタにボーダー追加 |
| `src/lib/post.ts` | 一覧で本文も展開するため `getFeedPosts()` を追加（render 済み Content を返す） |
| `src/pages/[...page].astro` | フィード形式へ全面的に書き換え。相対時刻表示は同日内のみ、それ以外は月日 / 年月日でフォーマット |
| `src/pages/posts/[postId].astro` | 投稿詳細を SNS ポスト風（アバター + 名前 + ハンドル → タイトル → 本文 → タイムスタンプ） |
| `src/pages/404.astro` | レイアウト変更に追従、ボタンを pill 化 |

## 補足

- 「投稿のハードルを下げて気軽に投稿できるようにする」という運用面の改善は #191 で別途対応予定
- `format:check` / `lint` / `build` 通過確認済み

## Test plan

- [ ] `npm run dev` で開発サーバを起動し、トップページがフィード形式で表示されること
- [ ] 一覧の各投稿で本文（画像 / リンク含む）が展開されていること
- [ ] 投稿内のリンクをクリックすると外部リンクへ正しく遷移すること（一覧でリンクのネストが起きていないこと）
- [ ] アバター / 名前 / ハンドル / 時刻 / タイトル いずれをクリックしても投稿詳細ページに遷移すること
- [ ] 投稿詳細ページが SNS ポスト風レイアウトで表示されること
- [ ] ページネーションが pill 型で動作すること
- [ ] 404 ページが新レイアウトで表示されること
- [ ] モバイルサイズでも崩れがないこと
- [ ] 一覧の画像が `max-h-80` でアスペクト比を保ったまま縮んで表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)