### PR TITLE
feat: 連続画像を SNS 風 grid レイアウトで表示

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,7 @@ import tailwindcss from "@tailwindcss/vite";
 import vercel from "@astrojs/vercel";
 import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
+import rehypeImageGrid from "./src/plugins/rehype-image-grid.mjs";
 import rehypeImageSize from "./src/plugins/rehype-image-size.mjs";
 import rehypeLinkCard from "./src/plugins/rehype-link-card.mjs";
 
@@ -17,7 +18,7 @@ export default defineConfig({
     },
   }),
   markdown: {
-    rehypePlugins: [rehypeLinkCard, rehypeImageSize],
+    rehypePlugins: [rehypeLinkCard, rehypeImageGrid, rehypeImageSize],
   },
   vite: {
     plugins: [tailwindcss()],

--- a/src/plugins/rehype-image-grid.mjs
+++ b/src/plugins/rehype-image-grid.mjs
@@ -1,0 +1,94 @@
+import { SKIP, visit } from "unist-util-visit";
+
+const isWhitespaceText = (node) =>
+  node.type === "text" && node.value.trim() === "";
+
+const isBr = (node) => node.type === "element" && node.tagName === "br";
+
+const isImg = (node) => node.type === "element" && node.tagName === "img";
+
+/**
+ * 連続する複数の <img> を <div class="image-grid image-grid-N"> に変換する
+ * rehype プラグイン
+ *
+ * <p> を <br> で chunk に分割し、img のみで構成される chunk (2+ 枚) を
+ * 独立した grid コンテナに切り出す。前後のテキスト系 chunk は <p> に戻す。
+ */
+export default function rehypeImageGrid() {
+  return (tree) => {
+    visit(tree, "element", (node, index, parent) => {
+      if (node.tagName !== "p") return;
+      if (!parent || typeof index !== "number") return;
+
+      const chunks = [[]];
+      for (const child of node.children) {
+        if (isBr(child)) {
+          chunks.push([]);
+        } else {
+          chunks[chunks.length - 1].push(child);
+        }
+      }
+
+      const classified = chunks.map((chunk) => {
+        const meaningful = chunk.filter((c) => !isWhitespaceText(c));
+        const isGrid = meaningful.length >= 2 && meaningful.every(isImg);
+        return { chunk, meaningful, isGrid };
+      });
+
+      if (!classified.some((c) => c.isGrid)) return;
+
+      const newNodes = [];
+      let pending = [];
+
+      const flushPending = () => {
+        if (pending.length === 0) return;
+        const children = [];
+        pending.forEach((chunk, i) => {
+          if (i > 0) {
+            children.push({
+              type: "element",
+              tagName: "br",
+              properties: {},
+              children: [],
+            });
+          }
+          children.push(...chunk);
+        });
+        const hasContent = children.some(
+          (c) => !isWhitespaceText(c) && !isBr(c),
+        );
+        if (hasContent) {
+          newNodes.push({
+            type: "element",
+            tagName: "p",
+            properties: { ...(node.properties ?? {}) },
+            children,
+          });
+        }
+        pending = [];
+      };
+
+      for (const { chunk, meaningful, isGrid } of classified) {
+        if (isGrid) {
+          flushPending();
+          const count = meaningful.length;
+          const variant = count >= 5 ? "many" : String(count);
+          newNodes.push({
+            type: "element",
+            tagName: "div",
+            properties: {
+              className: ["image-grid", `image-grid-${variant}`],
+            },
+            children: meaningful,
+          });
+        } else {
+          pending.push(chunk);
+        }
+      }
+      flushPending();
+
+      parent.children.splice(index, 1, ...newNodes);
+      return [SKIP, index + newNodes.length];
+    });
+  };
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -91,3 +91,59 @@
     margin: 0;
   }
 }
+
+/* 連続画像のグリッド表示 (X / Instagram 風)
+ * Typography plugin の .prose img 関連スタイルを上書きするため
+ * utilities layer に置く */
+@layer utilities {
+  .image-grid {
+    display: grid;
+    gap: 4px;
+    margin: 1rem 0;
+    border-radius: 1rem;
+    overflow: hidden;
+    width: 100%;
+    max-width: 100%;
+    background-color: #e5e7eb;
+  }
+
+  .image-grid > img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    border-radius: 0;
+    max-width: none;
+    max-height: none;
+    margin: 0;
+  }
+
+  .image-grid-2 {
+    grid-template-columns: 1fr 1fr;
+    aspect-ratio: 16 / 9;
+  }
+
+  .image-grid-3 {
+    grid-template-columns: 2fr 1fr;
+    grid-template-rows: 1fr 1fr;
+    aspect-ratio: 16 / 9;
+  }
+
+  .image-grid-3 > :first-child {
+    grid-row: 1 / span 2;
+  }
+
+  .image-grid-4 {
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 1fr 1fr;
+    aspect-ratio: 1 / 1;
+  }
+
+  .image-grid-many {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .image-grid-many > img {
+    aspect-ratio: 1 / 1;
+  }
+}


### PR DESCRIPTION
## 概要

複数画像を連続で添付した投稿を、X / Instagram 風の grid レイアウトで表示するようにしました。

例: `47y0o7ovmd3r.md`（龍ヶ鼻ダム） では、4 枚連続添付の箇所が 2×2、2 枚連続の箇所が横並びの grid に変換されます。

## 変更内容

- `src/plugins/rehype-image-grid.mjs` (新規)
  - `<p>` の子要素を `<br>` で chunk に分割し、img のみで 2 枚以上ある chunk を `<div class="image-grid image-grid-N">` に切り出す rehype プラグイン
  - 単独画像 (1 枚のみ) はそのまま、テキスト混在の段落は `<p>` を維持
- `astro.config.mjs`
  - `rehypeLinkCard` の後、`rehypeImageSize` の前に登録
- `src/styles/global.css`
  - 枚数別の grid レイアウト (2: 横並び / 3: 1 大 + 2 / 4: 2×2 / 5+: 3 列) を `@layer utilities` に定義
  - `.image-grid > img` の specificity を typography plugin の `.prose img` 系より優先するよう配置

## 動作確認

- `npm run format:check` / `lint` / `build` すべてパス
- ビルド出力で既存記事が `image-grid-4` / `image-grid-2` に正しく変換されることを確認

なお視覚確認は CLAUDE.md 指定の lightpanda エンジンが描画を持たないため省略しています。デプロイプレビューでの目視確認をお願いします。